### PR TITLE
ショップごとの合計金額を表示する

### DIFF
--- a/commands/deck.js
+++ b/commands/deck.js
@@ -31,7 +31,11 @@ async function searchDeck(deck_url, allow_english = false, shop_count = 3, outpu
   }
 
   let message_list = []
+  const shopTotals = {}  // { shopName: { total, count } }
+  let totalCards = 0
+
   for (const card_name of site.deck_list) {
+    totalCards++
     const sf = await Scryfall.build(card_name)
     if (sf.eng_name == null) {
       message_list.push({ name: card_name, error: `${card_name}が見つかりませんでした` })
@@ -39,9 +43,25 @@ async function searchDeck(deck_url, allow_english = false, shop_count = 3, outpu
     }
     const wg = await WisdomGuild.build(sf.eng_name, sf.jpn_name, allow_english, shop_count, output_english)
     message_list.push({ name: sf.jpn_name ?? sf.eng_name, row: wg.row })
+
+    for (const [shop, price] of Object.entries(wg.shopPrices)) {
+      if (!shopTotals[shop]) shopTotals[shop] = { total: 0, count: 0, cards: [] }
+      shopTotals[shop].total += price
+      shopTotals[shop].count++
+      shopTotals[shop].cards.push({ name: sf.jpn_name ?? sf.eng_name, price })
+    }
   }
 
-  return message_list
+  const summary = Object.entries(shopTotals)
+    .map(([shop, { total, count, cards }]) => ({
+      shop,
+      total,
+      missing: totalCards - count,
+      cards: cards.sort((a, b) => a.price - b.price),
+    }))
+    .sort((a, b) => a.total - b.total)
+
+  return { list: message_list, summary }
 }
 
 async function executeCommand(interaction) {
@@ -49,7 +69,8 @@ async function executeCommand(interaction) {
   const allow_english = interaction.options.getBoolean(ARG2) ?? false
   const shop_count = interaction.options.getInteger(ARG3) ?? 3
   const output_english = interaction.options.getBoolean(ARG4) ?? false
-  return searchDeck(deck_url, allow_english, shop_count, output_english)
+  const { list } = await searchDeck(deck_url, allow_english, shop_count, output_english)
+  return list
 }
 
 module.exports = {

--- a/docs/index.html
+++ b/docs/index.html
@@ -102,6 +102,48 @@
     .result-row a { color: #60a5fa; text-decoration: none; }
     .result-row a:hover { text-decoration: underline; }
 
+    .price-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.85rem;
+    }
+
+    .price-table th {
+      text-align: left;
+      color: #9ca3af;
+      border-bottom: 1px solid #2d2d5e;
+      padding: 0.25rem 0.5rem;
+    }
+
+    .price-table td {
+      padding: 0.25rem 0.5rem;
+      border-bottom: 1px solid #1e2a4a;
+    }
+
+    .price-table tr:last-child td { border-bottom: none; }
+
+    .price-table a { color: #60a5fa; text-decoration: none; }
+    .price-table a:hover { text-decoration: underline; }
+
+    .price-cell { text-align: right; color: #a78bfa; }
+
+    .summary-section {
+      margin-bottom: 1rem;
+      padding-bottom: 1rem;
+      border-bottom: 2px solid #2d2d5e;
+    }
+
+    .summary-title {
+      font-weight: bold;
+      margin-bottom: 0.4rem;
+      color: #a78bfa;
+    }
+
+    .summary-row { cursor: pointer; }
+    .summary-row:hover { background: #1e2a4a; }
+
+    .missing-cell { color: #f87171; }
+
     .error-msg { color: #f87171; }
     .loading { color: #9ca3af; font-style: italic; }
 
@@ -313,9 +355,48 @@
         })
         const data = await res.json()
         if (!res.ok) throw new Error(data.error)
-        resultBox.innerHTML = data.list.map(item =>
+        let html = ""
+
+        if (data.summary && data.summary.length > 0) {
+          const summaryRows = data.summary.map(({ shop, total, missing, cards }, index) => {
+            const detailRows = cards.map(c =>
+              `<tr><td style="padding-left:1.5rem">${c.name}</td><td class="price-cell">${c.price.toLocaleString()}円</td></tr>`
+            ).join("")
+            return `<tr class="summary-row" data-target="summary-detail-${index}">
+              <td>${shop} <span class="toggle-icon">▶</span></td>
+              <td class="price-cell">${total.toLocaleString()}円</td>
+              <td class="${missing > 0 ? "missing-cell" : ""}">${missing > 0 ? `${missing}枚取扱なし` : "全取扱"}</td>
+            </tr>
+            <tr id="summary-detail-${index}" style="display:none">
+              <td colspan="3" style="padding:0">
+                <table class="price-table"><tbody>${detailRows}</tbody></table>
+              </td>
+            </tr>`
+          }).join("")
+          html += `<div class="summary-section">
+            <div class="summary-title">ショップ別合計（行をクリックで詳細表示）</div>
+            <table class="price-table">
+              <thead><tr><th>ショップ</th><th>合計金額</th><th>取扱状況</th></tr></thead>
+              <tbody>${summaryRows}</tbody>
+            </table>
+          </div>`
+        }
+
+        html += data.list.map(item =>
           `<div class="result-row">${item.error ? `<span class="error-msg">${item.error}</span>` : renderRow(item.row)}</div>`
         ).join("")
+
+        resultBox.innerHTML = html
+
+        resultBox.querySelectorAll(".summary-row").forEach(row => {
+          row.addEventListener("click", () => {
+            const detail = document.getElementById(row.dataset.target)
+            const icon = row.querySelector(".toggle-icon")
+            const open = detail.style.display !== "none"
+            detail.style.display = open ? "none" : ""
+            icon.textContent = open ? "▶" : "▼"
+          })
+        })
       } catch (e) {
         resultBox.innerHTML = `<span class="error-msg">${e.message}</span>`
       } finally {

--- a/server.js
+++ b/server.js
@@ -65,13 +65,13 @@ app.get("/api/deck", authenticate, async (req, res) => {
   if (!url) return res.status(400).json({ error: "url パラメータが必要です" })
 
   try {
-    const list = await searchDeck(
+    const { list, summary } = await searchDeck(
       url,
       allow_english === "true",
       shop_count ? parseInt(shop_count, 10) : 3,
       output_english === "true"
     )
-    res.json({ list })
+    res.json({ list, summary })
   } catch (e) {
     res.status(500).json({ error: e.message })
   }

--- a/util/wisdomguild.js
+++ b/util/wisdomguild.js
@@ -18,8 +18,9 @@ const priority_threshold = "100"
 class WisdomGuild {
   constructor() {
     this.row
+    this.shopPrices
   }
-  
+
   static async build(eng_name, jpn_name, allow_english, shop_count, output_english) {
     const wg = new WisdomGuild()
     let lang_list = ["JPN"]
@@ -30,8 +31,9 @@ class WisdomGuild {
     if (output_english) {
       output_name = eng_name
     }
-    const price_list = await wg.fetchPriceList(eng_name, lang_list, shop_count);
+    const { price_list, shopPrices } = await wg.fetchPriceList(eng_name, lang_list, shop_count)
     wg.row = await wg.flatPriceList(output_name, price_list)
+    wg.shopPrices = shopPrices
 
     return wg
   }
@@ -88,22 +90,31 @@ class WisdomGuild {
       }
     }
     
+    // 全ショップの最安値を集計
+    const shopPrices = {}
+    for (const shop_dict of Object.values(price_dict)) {
+      for (const [shop, data] of Object.entries(shop_dict)) {
+        shopPrices[shop] = parseInt(data[0])
+      }
+    }
+
     if (Object.keys(price_dict).length == 0) {
       result_list.push([0, null, null, base_url])
+      return { price_list: result_list, shopPrices }
     }
 
     const price_key_list = Object.keys(price_dict).sort(collator.compare)
-    
+
     for (const price_key of price_key_list) {
       const shop_dict = price_dict[price_key]
       const shop_key_list = Object.keys(shop_dict).sort(collator.compare)
-      
+
       for (const shop_key of shop_key_list) {
         result_list.push(shop_dict[shop_key])
       }
     }
-    
-    return result_list.splice(0, shop_count)
+
+    return { price_list: result_list.splice(0, shop_count), shopPrices }
   }
 
   async flatPriceList(output_name, price_list) {


### PR DESCRIPTION
- searchDeckにショップ別合計集計（summaryフィールド）を追加
- WisdomGuildに全ショップ価格を収集するshopPricesを追加
- index.htmlにショップ別合計テーブルとカード詳細の展開表示を追加

### 【仕様メモ】
ショップ別合計はカード表示（上位N店）ではなく                                                                                                                         wisdom-guild掲載の全ショップ価格を集計している。
これにより「このショップ1店で全部買った場合の正確な合計金額」を算出できるが、                                                                                                   
カード単体の表示には出ない高値ショップも合計に含まれる点に注意。                                                                                                                
詳細はショップ行をクリックして確認可能。

  具体例

  あるカード（非表示）:  
    1位 シングルスター: 100円  
    2位 晴れる屋:     200円  
    3位 MINT MALL:    300円  
    4位 BIGWEB:      6,100円  ← 表示されないが合計に加算される  